### PR TITLE
Release docker image for arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: ci
+
+on:
+  pull_request:
+  push:
+    branches:
+      - local_pr
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login do docker.io
+        run: docker login -u odidev -p ${{ secrets.DOCKER_TOKEN }}
+      - name: build and publish image
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            odidev/concourse-metadata-resource:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:alpine as builder
 COPY . /go/src/github.com/swce/metadata-resource
 ENV CGO_ENABLED 0
+RUN go env -w GO111MODULE=off
 ENV GOPATH /go/src/github.com/swce/metadata-resource/Godeps/_workspace:${GOPATH}
 ENV PATH /go/src/github.com/swce/metadata-resource/Godeps/_workspace/bin:${PATH}
 RUN go build -o /assets/out github.com/swce/metadata-resource/out

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/output_interceptor_unix.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/output_interceptor_unix.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"io/ioutil"
 	"os"
-	"syscall"
 )
 
 func NewOutputInterceptor() OutputInterceptor {
@@ -30,9 +29,12 @@ func (interceptor *outputInterceptor) StartInterceptingOutput() error {
 	if err != nil {
 		return err
 	}
-
-	syscall.Dup2(int(interceptor.redirectFile.Fd()), 1)
-	syscall.Dup2(int(interceptor.redirectFile.Fd()), 2)
+	// Call a function in ./syscall_dup_*.go
+	// If building for everything other than linux_arm64,
+	// use a "normal" syscall.Dup2(oldfd, newfd) call. If building for linux_arm64 (which doesn't have syscall.Dup2)
+	// call syscall.Dup3(oldfd, newfd, 0). They are nearly identical, see: http://linux.die.net/man/2/dup3
+	syscallDup(int(interceptor.redirectFile.Fd()), 1)
+	syscallDup(int(interceptor.redirectFile.Fd()), 2)
 
 	return nil
 }

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/syscall_dup_linux_arm64.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/syscall_dup_linux_arm64.go
@@ -1,0 +1,11 @@
+// +build linux,arm64
+
+package remote
+
+import "syscall"
+
+// linux_arm64 doesn't have syscall.Dup2 which ginkgo uses, so
+// use the nearly identical syscall.Dup3 instead
+func syscallDup(oldfd int, newfd int) (err error) {
+	return syscall.Dup3(oldfd, newfd, 0)
+}

--- a/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/syscall_dup_unix.go
+++ b/Godeps/_workspace/src/github.com/onsi/ginkgo/internal/remote/syscall_dup_unix.go
@@ -1,0 +1,10 @@
+// +build !linux !arm64
+// +build !windows
+
+package remote
+
+import "syscall"
+
+func syscallDup(oldfd int, newfd int) (err error) {
+	return syscall.Dup2(oldfd, newfd)
+}


### PR DESCRIPTION
Hi

Package Owner: Abhishek Nishant

PR change Details:

Patch Details: Following file has been created and modified:

Added files **.github/workflows/ci.yml, syscall_dup_linux_arm64.go, syscall_dup_unix.go** and modified **Dockerfile** and **output_interceptor_unix.go** files to build and push the image for both amd64 and arm64 platforms.

PR Description: Here is my commit message:
Release docker image for arm64.

PR Description:

The following file has been created and modified:
Added files **.github/workflows/ci.yml, syscall_dup_linux_arm64.go, syscall_dup_unix.go** and modified **Dockerfile** and **output_interceptor_unix.go** files to build and push the image for both amd64 and arm64 platforms.


Signed-off-by: odidev odidev@puresoftware.com
Reviewer: Pruthvi Teja Reddy
Thanks
Abhishek Nishant